### PR TITLE
adding tag group support

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,3 +289,33 @@ __With group_by set to 'kernelversion'__
         ]
       }
     }
+
+__With group_by_tag set to__
+
+```
+#Puppet code example tagging class...
+class webservices_tag {
+
+  case $fqdn {
+    /\-dev/: { tag 'web-development' }
+    /\-production/: { tag 'web-production' }
+  }
+
+}
+```
+
+```
+group_by_tag:
+  - Class: web-development
+  - Class: web-production
+```
+
+Snippet of tagged group being added...
+```
+ "web-development": {
+   hosts: [ 'node01-dev.domain.tld', 'node02-dev.domain.tld' ]
+ }
+ "web-production": {
+   hosts: [ 'node01-production.domain.tld', 'node02-production.domain.tld' ]
+ }
+```

--- a/puppetdb.yml
+++ b/puppetdb.yml
@@ -29,6 +29,23 @@
 #   hosts: [ 'server5' ]
 # }
 #
+# == Notes on group_by_tags
+# This will generate ansible-compatible groups based on tag values
+# For example, if you want to group hosts based on the Puppet Class tag you tag
+# in your Puppet code "web-development" set group_by to this:
+#
+# group_by_tag:
+#   - Class: web-development
+#   - Class: web-production
+#
+# This will generate something like this:
+# "web-development": {
+#   hosts: [ 'node01-dev.domain.tld', 'node02-dev.domain.tld' ]
+# }
+# "web-production": {
+#   hosts: [ 'node01-production.domain.tld', 'node02-production.domain.tld' ]
+# }
+#
 # Regardless of whether or not group_by is set, the inventory will
 # always return a group called 'all' with all the hosts in it.
 #
@@ -43,3 +60,4 @@ ssl_cert:
 cache_file: '/tmp/ansible-inventory-puppetdb.cache'
 cache_duration: 30
 group_by:
+group_by_tag:


### PR DESCRIPTION
Adding support for grouping by Puppet 'tag' values.  You can tag at the different Puppet resource levels.  I included an example of grouping by at "Class" tag.  Other resources like "File" and "Service" can also be tagged and grouped.
