### PR TITLE
Removal of api_version for pypuppetdb-0.2.x compatibility

### DIFF
--- a/puppetdb.py
+++ b/puppetdb.py
@@ -75,7 +75,6 @@ class PuppetdbInventory(object):
 
         puppetdb_config = {
             'host': self.config.get('host'),
-            'api_version': self.config.get('api_version'),
             'port': self.config.get('port'),
             'timeout': self.config.get('timeout'),
             'ssl_verify': self.config.get('ssl_verify'),

--- a/puppetdb.yml
+++ b/puppetdb.yml
@@ -51,7 +51,6 @@
 #
 ---
 host: localhost
-api_version: 3
 port: 8080
 timeout: 10
 ssl_verify: False


### PR DESCRIPTION
api_version was removed from pypuppetdb-0.2.x so removing from here for compatibility.

Validated puppetdb.py functions against puppetdb v3.2.0, pypuppetdb-0.2.3.
