### PR TITLE
Add API v4 Backwards Compatibility

### DIFF
--- a/puppetdb.py
+++ b/puppetdb.py
@@ -83,6 +83,9 @@ class PuppetdbInventory(object):
             'ssl_cert': self.config.get('ssl_cert') or None
         }
 
+        if puppetdb_config['api_version'] == 4:
+            del puppetdb_config['api_version']
+
         self.puppetdb = connect(**puppetdb_config)
 
         self.cache_file = self.config.get('cache_file')

--- a/puppetdb.yml
+++ b/puppetdb.yml
@@ -49,6 +49,10 @@
 # Regardless of whether or not group_by is set, the inventory will
 # always return a group called 'all' with all the hosts in it.
 #
+# == Notes on api_version
+# When set to 4, this will allow the use of pypuppetdb 2.x, which deprecated
+# the api versions. If set to 4 with pypuppetdb 0.1.1 installed it will 
+# produce an invalid version error.
 ---
 host: localhost
 api_version: 3


### PR DESCRIPTION
Per discussion in #3, this allows the use of both 0.1 and 0.2 branches of pypuppetdb.
